### PR TITLE
Limit the number of job display on the homepage

### DIFF
--- a/app/assets/javascripts/jobs.js.coffee
+++ b/app/assets/javascripts/jobs.js.coffee
@@ -1,11 +1,21 @@
 $ ->
   $jobsList = $('#jobsList')
 
-  console.debug("HELLO")
+  numberOfDays = (rubyDate) ->
+    dateToday = new Date()
+    date = new Date(rubyDate)
+    timeDiff = Math.abs(dateToday.getTime() - date.getTime());
+    diffDays = Math.ceil(timeDiff / (1000 * 3600 * 24));
+
+
 
   if $jobsList.length > 0
     $.get 'https://jobs.rubyparis.org/en/job_offers.json', (jobs) ->
       job_links = $.map jobs, (job) ->
+        if(numberOfDays(job.updated_at) > 300)
+          return
+
+
         """
           <div class="job col-sm-3">
             <a class="job-link" href="https://jobs.rubyparis.org/en/job_offers/#{job.slug}">


### PR DESCRIPTION
On the homepage, it would be better to have the most recent jobs.
My PR display only the jobs updated during the last 300 days.