### PR TITLE
Fix Dockerfile to really use node 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@ FROM ruby:2.6.4
 RUN apt-get update
 RUN apt-get install apt-transport-https
 
+RUN apt-get update && apt-get install sudo && apt-get clean &&\
+    sed -i s+secure_path=.*+secure_path="$PATH"+ /etc/sudoers
+
+RUN curl -fsSL https://deb.nodesource.com/setup_8.x | sudo -E bash - &&\
+    apt-cache policy nodejs &&\
+    apt-get install -y nodejs=8.17.0-1nodesource1
+
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
@@ -12,13 +19,7 @@ RUN apt-get install -y imagemagick
 RUN apt-get install -y locales
 RUN apt-get install -y postgresql-client
 
-ENV NODE_VERSION 8.11.3
-
-RUN cd /opt && \
-    curl -L "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" | tar -xJf - && \
-    mv -v node-v$NODE_VERSION-linux-x64 node && \
-    apt-get update && apt-get install sudo && apt-get clean &&\
-    sed -i s+secure_path=.*+secure_path="$PATH"+ /etc/sudoers
+RUN node --version
 
 ENV GEM_HOME="/usr/src/app/vendor/.bundle"
 ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH


### PR DESCRIPTION
In the Dockerfile there is a command to force node version to 8.x

But with latest container, there is also node 10 in the sources and `apt install -y nodejs` takes v 10.x as it is newer
Also the manual download + install was not working as it is putting node in /opt which isn't in PATH and isn't overwriting the version installed by apt which is in /usr/bin/nodejs

Before:

```
ylecuyer@inwin:~/Projects/rubyparis.org$ docker-compose build
....
ylecuyer@inwin:~/Projects/rubyparis.org$ docker-compose run web node --version
WARNING: The CLOUDINARY_URL variable is not set. Defaulting to a blank string.
WARNING: The MAIL_URL variable is not set. Defaulting to a blank string.
Creating rubyparisorg_web_run ... done
v10.24.0
```

With fix:

```
ylecuyer@inwin:~/Projects/rubyparis.org$ docker-compose build
...
ylecuyer@inwin:~/Projects/rubyparis.org$ docker-compose run web node --version
WARNING: The CLOUDINARY_URL variable is not set. Defaulting to a blank string.
WARNING: The MAIL_URL variable is not set. Defaulting to a blank string.
Creating rubyparisorg_web_run ... done
v8.17.0
```

node version 8 is needed by node-sass because we use version 4.5.3 which is only compatible with node 8

https://www.npmjs.com/package/node-sass

![Screenshot_2021-11-06_22-06-03](https://user-images.githubusercontent.com/1866809/140623768-5c020179-d480-4a40-96e2-617956d3ac9b.png)
