### PR TITLE
Remove markdown helper

### DIFF
--- a/app/views/talks/index.html.slim
+++ b/app/views/talks/index.html.slim
@@ -10,7 +10,18 @@
       .col-xs-12.col-sm-5.col-sm-offset-1
         = render 'form'
       .col-xs-12.faq.col-sm-6
-        = markdown t('.faq')
+        h2 Je suis un newbie, et j'ai peeeeuuur de présenter
+        p À Paris.rb on n'est pas là pour se moquer des novices. Nous serons TOUJOURS ravis d'accueillir les talks débutants comme confirmés.
+
+        h2 Je voudrais faire une présentation de + de 20 minutes
+
+        p Les présentations sont chronometrées, dans le but de ne pas trop fatiguer les rubyistes qui vous écoutent, et des études ont prouvé que les 2 meilleurs timings sont : 5 minutes et 20 minutes.
+
+        h2 Je veux présenter ma société, ou mon produit
+
+        p Nous sommes ici pour parler de Ruby, de Rails, et du monde des startups sur Paris. Pour faire la promotion d'une société, d'un produit, ou rechercher un profil, la coutume est d'aider la communauté en sponsorisant les événements Ruby.
+
+        p == "Si vous avez d'autres questions, n'hésitez pas à envoyer un email à #{mail_to('thibaut@milesrock.com', 'Thibaut')}"
 
 .section.talks
   .container

--- a/app/views/videos/show.html.slim
+++ b/app/views/videos/show.html.slim
@@ -19,7 +19,7 @@
 
     .row
       .video-description.col-md-6.col-md-offset-3
-        = markdown video.description
+        p = simple_format(video.description)
 
     .row
       .video-event-date.col-md-6.col-md-offset-3.text-center.text-muted

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -80,28 +80,6 @@ fr:
       description: >-
         Voir la liste des talks proposés pour les prochains meetups. Proposez
         votre talk !
-      faq: |
-        ## Je suis un newbie, et j'ai peeeeuuur de présenter
-
-        À Paris.rb on n'est pas là pour se moquer des novices. Nous serons
-        TOUJOURS ravis d'accueillir les talks débutants comme confirmés.
-
-        ## Je voudrais faire une présentation de + de 20 minutes
-
-        Les présentations sont chronometrées, dans le but de ne pas trop
-        fatiguer les rubyistes qui vous écoutent, et des études ont prouvé
-        que les 2 meilleurs timings sont : 5 minutes et 20 minutes.
-
-        ## Je veux présenter ma société, ou mon produit
-
-        Nous sommes ici pour parler de Ruby, de Rails, et du monde des
-        startups sur Paris. Pour faire la promotion d'une société, d'un
-        produit, ou rechercher un profil, la coutume est d'aider la
-        communauté en sponsorisant les événements Ruby.
-
-        Si vous avez d'autres questions, n'hésitez pas à envoyer un email à
-        [Thibaut](mailto:thibaut@milesrock.com)
-
       lineup: Lineup du prochain meetup
       proposed_talks: Autres talks proposés
       happened_talks: Talks ayant déjà eu lieu


### PR DESCRIPTION
In order to remove the mustdown gem we need to remove the use of its helpers here the markdown helper