### PR TITLE
feat: update Slack link

### DIFF
--- a/app/views/lineup/_social_media.slim
+++ b/app/views/lineup/_social_media.slim
@@ -7,5 +7,5 @@ section
 
   ul
     li #{link_to 'https://www.twitch.tv/paris_rb', 'https://www.twitch.tv/paris_rb'}
-    li #{link_to 'http://parisrb-slack-invite.herokuapp.com', 'http://parisrb-slack-invite.herokuapp.com/'}
+    li #{link_to 'https://join.slack.com/t/parisrb/shared_invite/zt-1io48rnoz-97bt5glsJJAL1f9Gj06CRw', 'https://join.slack.com/t/parisrb/shared_invite/zt-1io48rnoz-97bt5glsJJAL1f9Gj06CRw'}
     li #{link_to 'https://www.meetup.com/parisrb', 'https://www.meetup.com/parisrb'}

--- a/app/views/shared/_navbar.html.slim
+++ b/app/views/shared/_navbar.html.slim
@@ -14,4 +14,4 @@ nav.navbar.navbar-default.navbar-static-top role="navigation"
         li = link_to 'Vidéos', videos_path
         li = link_to 'Proposer un talk', talks_path
         li = link_to 'Meetup', 'https://www.meetup.com/parisrb/'
-        li = link_to 'Slack', 'https://parisrb-slack-invite.herokuapp.com/'
+        li = link_to 'Slack', 'https://join.slack.com/t/parisrb/shared_invite/zt-1io48rnoz-97bt5glsJJAL1f9Gj06CRw'


### PR DESCRIPTION
Heroku app doesn't work anymore, free plan doesn't exist anymore. Using Slack link instead.