### PR TITLE
feat: remove email contact from talks page

### DIFF
--- a/app/views/talks/index.html.slim
+++ b/app/views/talks/index.html.slim
@@ -21,8 +21,6 @@
 
         p Nous sommes ici pour parler de Ruby, de Rails, et du monde des startups sur Paris. Pour faire la promotion d'une société, d'un produit, ou rechercher un profil, la coutume est d'aider la communauté en sponsorisant les événements Ruby.
 
-        p == "Si vous avez d'autres questions, n'hésitez pas à envoyer un email à #{mail_to('thibaut@milesrock.com', 'Thibaut')}"
-
 .section.talks
   .container
     h2 = t('.lineup')


### PR DESCRIPTION
Remove old contact email from talk page.

When a new email address is created, it will probably have to be added in place of the one that was deleted.